### PR TITLE
Add AMD support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ define(['ember'], function(Ember) {
 });
 ```
 
-
-
 #### processName
 Type: `function`
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Default: `true`
 
 Determine if preprocessed template functions will be wrapped in Ember.Handlebars.template function.
 
+#### amd
+Type: `Boolean`
+default: `false`
+
+Wraps the output file with an AMD define function and returns the compiled template namespace unless namespace has been explicitly set to false in which case the template function will be returned directly.
+Depends on Ember.js being availiable as an AMD module.
+```js
+define(['ember'], function(Ember) {
+    //...//
+    returns this['[template namespace]'];
+});
+```
+
+
+
 #### processName
 Type: `function`
 

--- a/tasks/ember-handlebars.js
+++ b/tasks/ember-handlebars.js
@@ -76,6 +76,10 @@ module.exports = function(grunt) {
           if (options.wrapped) {
             compiled = 'Ember.Handlebars.template('+compiled+')';
           }
+
+          if(options.amd && options.namespace === false) {
+            compiled = 'return ' + compiled;
+          }
         } catch (e) {
           grunt.log.error(e);
           grunt.fail.warn('Handlebars failed to compile '+filepath+'.');
@@ -96,6 +100,18 @@ module.exports = function(grunt) {
         grunt.log.warn('Destination not written because compiled files were empty.');
       } else {
         output.unshift(nsInfo.declaration);
+        
+        if (options.amd) {
+          // Wrap the file in an AMD define fn.
+          output.unshift("define(['ember'], function(Ember) {");
+          if (options.namespace !== false) {
+            // Namespace has not been explicitly set to false; the AMD
+            // wrapper will return the object containing the template.
+            output.push("return "+nsInfo.namespace+";");
+          }
+          output.push("});");
+        }
+
         grunt.file.write(f.dest, output.join(grunt.util.normalizelf(options.separator)));
         grunt.log.writeln('File "' + f.dest + '" created.');
       }


### PR DESCRIPTION
Ported the AMD wrapper option from https://github.com/gruntjs/grunt-contrib-handlebars.
The only change is that the dependency in this case is Ember.js instead of Handlebars.js
Added option to README
