### PR TITLE
don't strip leading underscore for partials

### DIFF
--- a/tasks/ember-handlebars.js
+++ b/tasks/ember-handlebars.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
   var defaultProcessPartialName = function(filePath) {
     var pieces = _.last(filePath.split('/')).split('.');
     var name   = _(pieces).without(_.last(pieces)).join('.'); // strips file extension
-    return name.substr(1, name.length);                       // strips leading _ character
+    return name;
   };
 
   grunt.registerMultiTask('ember_handlebars', 'Precompile Ember Handlebars templates.', function() {


### PR DESCRIPTION
Hi! Thanks for writing this library.

This fixes #15. To make this easily testable (avoid invoking the whole grunt task), I was considering refactoring some of the logic out of the task into a separate object. Let me know if you'd like me to take a stab at that or think this is fine as-is.
